### PR TITLE
Add xz-musl.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.xz-musl?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=189&branchName=master)
+
+# xz-musl
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+plan_name : "xz-musl"

--- a/controls/xz_musl_test.rb
+++ b/controls/xz_musl_test.rb
@@ -1,0 +1,30 @@
+title 'Tests to confirm xz-musl works as expected'
+
+plan_name = input('plan_name', value: 'xz-musl')
+plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+hab_path = input('hab_path', value: 'hab')
+
+control 'core-plans-xz-musl' do
+  impact 1.0
+  title 'Ensure xz-musl works'
+  desc '
+  For xz-musl we check that the version is correctly returned e.g.
+
+    $ xz --version
+    xz (XZ Utils) 5.2.5
+    liblzma 5.2.5
+  '
+  xz_musl_pkg_ident = command("#{hab_path} pkg path #{plan_ident}")
+  describe xz_musl_pkg_ident do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  xz_musl_pkg_ident = xz_musl_pkg_ident.stdout.strip
+
+  describe command("#{xz_musl_pkg_ident}/bin/xz --version") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /xz \(XZ Utils\)\s+#{xz_musl_pkg_ident.split('/')[5]}/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,7 +1,7 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
+name: xz-musl
+title: Habitat Core Plan xz-musl
 maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
+summary: InSpec controls for testing Habitat Core Plan xz-musl
 copyright: humans@habitat.sh
 copyright_email: humans@habitat.sh
 version: 0.1.0

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,59 @@
+pkg_name=xz-musl
+_distname="xz"
+pkg_origin=core
+pkg_version=5.2.4
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="\
+XZ Utils is free general-purpose data compression software with a high \
+compression ratio. XZ Utils were written for POSIX-like systems, but also \
+work on some not-so-POSIX systems. XZ Utils are the successor to LZMA Utils.\
+"
+pkg_upstream_url="http://tukaani.org/xz/"
+pkg_license=('gpl2+' 'lgpl2+')
+pkg_source="http://tukaani.org/${_distname}/${_distname}-${pkg_version}.tar.gz"
+pkg_shasum="b512f3b726d3b37b6dc4c8570e137b9311e7552e8ccbab4d39d47ce5f4177145"
+pkg_dirname="${_distname}-${pkg_version}"
+pkg_deps=(
+  core/musl
+)
+pkg_build_deps=(
+  core/coreutils
+  core/diffutils
+  core/patch
+  core/make
+  core/gcc
+  core/sed
+)
+pkg_bin_dirs=(bin)
+pkg_include_dirs=(include)
+pkg_lib_dirs=(lib)
+pkg_pconfig_dirs=(lib/pkgconfig)
+
+do_check() {
+  make check
+}
+
+do_prepare() {
+  export CC=musl-gcc
+  build_line "Setting CC=$CC"
+
+  dynamic_linker="$(pkg_path_for musl)/lib/ld-musl-x86_64.so.1"
+  LDFLAGS="$LDFLAGS -Wl,--dynamic-linker=$dynamic_linker"
+}
+
+
+# ----------------------------------------------------------------------------
+# **NOTICE:** What follows are implementation details required for building a
+# first-pass, "stage1" toolchain and environment. It is only used when running
+# in a "stage1" Studio and can be safely ignored by almost everyone. Having
+# said that, it performs a vital bootstrapping process and cannot be removed or
+# significantly altered. Thank you!
+# ----------------------------------------------------------------------------
+if [[ "$STUDIO_TYPE" = "stage1" ]]; then
+  pkg_build_deps=(
+    core/gcc
+    core/coreutils
+    core/sed
+    core/diffutils
+  )
+fi


### PR DESCRIPTION
Migration from core plans, minus previous source pattern.

```
Profile: Habitat Core Plan xz-musl (xz-musl)
Version: 0.1.0
Target:  docker://52c6cc8db05b7b82132e0e58d6d5f06071826080c6c09a3bee1a3147a030d7f2

  ✔  core-plans-xz-musl: Ensure xz-musl works
     ✔  Command: `hab pkg path habskp/xz-musl` exit_status is expected to eq 0
     ✔  Command: `hab pkg path habskp/xz-musl` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/habskp/xz-musl/5.2.4/20200610092454/bin/xz --version` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/habskp/xz-musl/5.2.4/20200610092454/bin/xz --version` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/habskp/xz-musl/5.2.4/20200610092454/bin/xz --version` stdout is expected to match /xz \(XZ Utils\)\s+5.2.4/
     ✔  Command: `/hab/pkgs/habskp/xz-musl/5.2.4/20200610092454/bin/xz --version` stderr is expected to be empty
```

﻿Signed-off-by: Stuart Paterson <spaterson@chef.io>
